### PR TITLE
[ONLINE-293] Fix Lodash versions conflicting due to object leakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For usage within a web page, paste the following snippet into the header of your
 
 ```html
 <script type="text/javascript">
-!function(e,r,t,s,a){e.__visearch_obj=a;var c=e[a]=e[a]||{};c.q=c.q||[],c.factory=function(r){return function(){var e=Array.prototype.slice.call(arguments);return e.unshift(r),c.q.push(e),c}},c.methods=["idsearch","uploadsearch","colorsearch","set","send","search","recommendation","out_of_stock","similarproducts","discoversearch"];for(var o=0;o<c.methods.length;o++){var n=c.methods[o];c[n]=c.factory(n)}var i=r.createElement(t);i.type="text/javascript",i.async=!0,i.src="//cdn.visenze.com/visearch/dist/js/visearch-1.5.0.min.js";var h=r.getElementsByTagName(t)[0];h.parentNode.insertBefore(i,h)}(window,document,"script",0,"visearch");
+!function(e,r,t,s,a){e.__visearch_obj=a;var c=e[a]=e[a]||{};c.q=c.q||[],c.factory=function(r){return function(){var e=Array.prototype.slice.call(arguments);return e.unshift(r),c.q.push(e),c}},c.methods=["idsearch","uploadsearch","colorsearch","set","send","search","recommendation","out_of_stock","similarproducts","discoversearch"];for(var o=0;o<c.methods.length;o++){var n=c.methods[o];c[n]=c.factory(n)}var i=r.createElement(t);i.type="text/javascript",i.async=!0,i.src="//cdn.visenze.com/visearch/dist/js/visearch-1.5.1.min.js";var h=r.getElementsByTagName(t)[0];h.parentNode.insertBefore(i,h)}(window,document,"script",0,"visearch");
 visearch.set('app_key', 'YOUR_APP_KEY');
 </script>
 ```

--- a/js/visearch.js
+++ b/js/visearch.js
@@ -294,11 +294,11 @@
         const values = params[param];
         if (Array.isArray(values)) {
           for (const i in values) {
-            if (values.hasOwnProperty(i)) {
+            if (values.hasOwnProperty(i) && values[i] != null) {
               postData.append(param, values[i]);
             }
           }
-        } else {
+        } else if (values != null) {
           postData.append(param, values);
         }
       }

--- a/js/visearch.js
+++ b/js/visearch.js
@@ -403,4 +403,10 @@
   if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
     module.exports = $visearch;
   }
+
+  // Fix Lodash object leaking to window due to Webpack issue
+  // Reference: https://github.com/webpack/webpack/issues/4465
+  if (typeof window !== 'undefined' && window._ && window._.noConflict) {
+    window._.noConflict();
+  }
 }(typeof self !== 'undefined' ? self : this));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visearch-javascript-sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "JavaScript SDK for ViSearch of visenze.com",
   "main": "./js/index.js",
   "scripts": {


### PR DESCRIPTION
As it turns out, Lodash leaking to the `window` object is a widely known problem (https://github.com/webpack/webpack/issues/4465) with no proper solution (many workarounds exist). Using `_.noConflict()` is probably the safest of all of them.