### PR TITLE
[ES-9076] Model image should show as the reference image for STL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visearch-javascript-sdk",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "JavaScript SDK for ViSearch of visenze.com",
   "main": "cjs/index.js",
   "module": "esm/index.js",

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -121,6 +121,12 @@ export interface GroupProductResponse {
   result: Product[];
 }
 
+export interface BestImage {
+  type: string;
+  url: string;
+  index: string;
+}
+
 export interface Product {
   product_id: string;
   main_image_url: string;
@@ -128,6 +134,7 @@ export interface Product {
   score?: number;
   image_s3_url?: string;
   pinned?: 'true' | 'false';
+  best_images?: BestImage[];
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Add best_images field in product_info field as part of response when the query params show_best_product_images=true

![Screenshot 2024-02-20 at 1 44 35 PM](https://github.com/visenze/visearch-sdk-javascript/assets/70419463/ccd8eb92-3ac3-430b-b5fb-0d12e89e1564)
