### PR TITLE
[MC-2827] docs: rebrand ViSenze references to Rezolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![npm version](https://img.shields.io/npm/v/visearch-javascript-sdk.svg?style=flat)](https://www.npmjs.com/package/visearch-javascript-sdk)
 
-ViSenze's Javascript SDK provides accurate, reliable and scalable image search APIs within our catalogs. The APIs included in this SDK aims to provide developers with endpoints that executes image search efficiently while also making it easy to integrate into webapps.
+Rezolve's Javascript SDK provides accurate, reliable and scalable image search APIs within our catalogs. The APIs included in this SDK aims to provide developers with endpoints that executes image search efficiently while also making it easy to integrate into webapps.
 
-> Note: In order to use any of our SDKs, you are required to have a ViSenze developer account. You will gain access to your own dashboard to manage your appkeys and catalogs. Visit [here](https://console.visenze.com) for more info.
+> Note: In order to use any of our SDKs, you are required to have a Rezolve developer account. You will gain access to your own dashboard to manage your appkeys and catalogs. Visit [here](https://ms.console.rezolve.com/) for more info.
 
 ----
 
@@ -113,7 +113,7 @@ npm install visearch-javascript-sdk
 
 #### 1.2.2 Configure keys
 
-Before you can start using the SDK, you will need to set up . Most of these keys can be found in your account's [dashboard](https://console.visenze.com).
+Before you can start using the SDK, you will need to set up . Most of these keys can be found in your account's [dashboard](https://ms.console.rezolve.com/).
 
 Please take a look at the table below to understand what each key represents:
 
@@ -121,7 +121,7 @@ Please take a look at the table below to understand what each key represents:
 |:---|:---|:---|
 | app_key | Compulsory | All SDK functions depends on a valid app_key being set. The app key also limits the API features you can use. |
 | placement_id | Compulsory | Placement id of the current placement |
-| endpoint | Situational | Default is `https://search.visenze.com/` |
+| endpoint | Situational | Default is `https://search.visenze.com/` (AWS). For Azure-deployed apps, use `https://multimodal.search.rezolve.com/` |
 | timeout | Optional | Defaulted to 15000 |
 | uid | Optional | If this is not provided, we will auto generate the uid |
 
@@ -274,7 +274,7 @@ Searching by Image can happen in three different ways - by url, id or File.
   visearch.productSearchByImage(parameters, onResponse, onError);
   ```
 
-> The request parameters for this API can be found at [ViSenze Documentation Hub](https://ref-docs.visenze.com/reference/search-by-image-api-1).
+> The request parameters for this API can be found at [Rezolve Documentation Hub](https://msdocs.rezolve.com/reference/search-by-image-api-1).
 
 ### 2.2 Recommendations
 
@@ -299,7 +299,7 @@ const onError = (error)=> {
 visearch.productRecommendations(product_id, parameters, onResponse, onError);
 ```
 
-> The request parameters for this API can be found at [ViSenze Documentation Hub](https://ref-docs.visenze.com/reference/search-by-image-api-1).
+> The request parameters for this API can be found at [Rezolve Documentation Hub](https://msdocs.rezolve.com/reference/search-by-image-api-1).
 
 ### 2.3 Multisearch
 
@@ -404,7 +404,7 @@ Multisearch can happen in five different ways - by text, product id, image url, 
   visearch.productMultisearch(parameters, onResponse, onError);
   ```
 
-> The request parameters for this API can be found at [ViSenze Documentation Hub](https://ref-docs.visenze.com/reference/multimodal-api).
+> The request parameters for this API can be found at [Rezolve Documentation Hub](https://msdocs.rezolve.com/reference/multimodal-api).
 
 ### 2.4 Multisearch Complementary
 
@@ -510,7 +510,7 @@ Multisearch complementary can happen with product id / image url /image id / ima
   visearch.productMultisearchComplementary(parameters, onResponse, onError);
   ```
 
-> The request parameters for this API can be found at [ViSenze Documentation Hub](https://ref-docs.visenze.com/reference/multimodal-complementary-api).
+> The request parameters for this API can be found at [Rezolve Documentation Hub](https://msdocs.rezolve.com/reference/multimodal-complementary-api).
 
 ### 2.5 Multisearch Outfit Recommendations
 
@@ -616,7 +616,7 @@ Multisearch outfit recommendations can happen with product id / image url /image
   visearch.productMultisearchOutfitRecommendations(parameters, onResponse, onError);
   ```
 
-> The request parameters for this API can be found at [ViSenze Documentation Hub](https://ref-docs.visenze.com/reference/multimodal-outfit-recommendations-api).
+> The request parameters for this API can be found at [Rezolve Documentation Hub](https://msdocs.rezolve.com/reference/multimodal-outfit-recommendations-api).
 
 ### 2.6 Multisearch Autocomplete
 
@@ -721,7 +721,7 @@ Multisearch autocomplete can happen in five different ways - by text, product id
   visearch.productMultisearchAutocomplete(parameters, onResponse, onError);
   ```
 
-> The request parameters for this API can be found at [ViSenze Documentation Hub](https://ref-docs.visenze.com/reference/multimodal-autocomplete-api).
+> The request parameters for this API can be found at [Rezolve Documentation Hub](https://msdocs.rezolve.com/reference/multimodal-autocomplete-api).
 
 
 ## 3. Search Results
@@ -772,7 +772,7 @@ The fields returned under here are dependent on the product metadata requested t
 
 Other than that, we return 2 default fields.
 
-|ViSenze pre-defined catalog fields|Client X's catalog original names|
+|Rezolve pre-defined catalog fields|Client X's catalog original names|
 |:---|:---|
 |product_id|sku|
 |main_image_url|medium_image|
@@ -798,7 +798,7 @@ Facets are used to perform potential filtering of results.
 | items | [object](#36-facetitem)[] |  |
 | range | [object](#37-facetrange) |  |
 
-To check usage guideline, please refer [here](https://ref-docs.visenze.com/reference/facets)
+To check usage guideline, please refer [here](https://msdocs.rezolve.com/reference/facets)
 
 ### 3.6 FacetItem
 
@@ -822,7 +822,7 @@ Facet for value range filtering.
 
 There are many parameters that our API support and we will be showing you a few examples of how to use them in this section.
 
-> You can find all of the supported advance search parameters for ProductSearch API [here](https://ref-docs.visenze.com/reference/search-by-image-api-1).
+> You can find all of the supported advance search parameters for ProductSearch API [here](https://msdocs.rezolve.com/reference/search-by-image-api-1).
 
 ### 4.1 Example - Retrieving Metadata
 
@@ -868,7 +868,7 @@ Params | Filter Query Behaviour | Example
 --- | --- | ---
 string | The filter queries are treated as exact match conditions. Applies to String, Integer and Float type fields. | `filters=brand:my_brand` means the brand (String) value of the search results must be strictly equal to “my_brand”. `filters=price:10,199` means the price (Integer) value of the search results must be strictly within the range between 10 to 199 inclusive.
 
-For more details, check out [Filters and Text Filters](https://ref-docs.visenze.com/reference/filters-and-text-filters) section in the ViSenze Documentation Hub.
+For more details, check out [Filters and Text Filters](https://msdocs.rezolve.com/reference/filters-and-text-filters) section in the Rezolve Documentation Hub.
 
 ### 4.3 Example - Automatic Object Recognition
 


### PR DESCRIPTION
Update README with new Rezolve branding following acquisition:
- Replace ViSenze company name with Rezolve throughout
- Update console URL to ms.console.rezolve.com
- Update ref-docs.visenze.com to msdocs.rezolve.com
- Update endpoint note to clarify AWS vs Azure domains